### PR TITLE
SUIT-9267 Adjust usage of assert.fail according to node's deprecation warning

### DIFF
--- a/lib/utils/socketChainHelper.js
+++ b/lib/utils/socketChainHelper.js
@@ -45,13 +45,12 @@ const processServerResponse = toString => function processServerResponseHandler(
 	if (res.result !== 'success' && res.contentType === 'testLine' && isAssertionError) {
 		const {actualValue, expectedValue} = getActualExpectedValues(res, data);
 
-		assert.fail(
-			actualValue,
-			expectedValue,
-			getAssertErrorMessage(res, toString(data), data),
-			null,
-			processServerResponseHandler
-		);
+		throw new assert.AssertionError({
+			actual: actualValue,
+			expected: expectedValue,
+			message: getAssertErrorMessage(res, toString(data), data),
+			stackStartFn: processServerResponseHandler,
+		});
 	}
 
 	throw new SuitestError(res.errorType || res.error);


### PR DESCRIPTION
assert.fail calling replaced to assert.AssertionError throwing