### PR TITLE
SUIT-9592 Update useSentry flag naming in JS API changed to disallowCrashReports

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -6,7 +6,7 @@ const {invalidConfigObj} = require('../lib/texts');
 
 const sentryDsn = 'https://1f74b885d0c44549b57f307733d60351:dd736ff3ac994104ab6635da53d9be2e@sentry.io/288812';
 
-const rcConfigFields = ['logLevel', 'useSentry'];
+const rcConfigFields = ['logLevel', 'disallowCrashReports'];
 const rcLauncherFields = [
 	'tokenKey', 'tokenPassword', 'testPackId', 'concurrency', // launcher automated
 	'username', 'password', 'orgId', 'deviceId', 'appConfigId', 'inspect', 'inspectBrk', // launcher intaractive
@@ -16,7 +16,7 @@ const rcLauncherFields = [
 const main = {
 	apiUrl: 'https://the.suite.st/api/public/v2',
 	sentryDsn,
-	useSentry: true,
+	disallowCrashReports: false,
 	wsUrl: 'wss://the.suite.st/api/public/v2/socket',
 	logLevel: logLevels.normal,
 };
@@ -24,7 +24,7 @@ const main = {
 const test = {
 	apiUrl: 'https://localhost',
 	sentryDsn,
-	useSentry: true,
+	disallowCrashReports: false,
 	wsUrl: 'ws://localhost:3000/',
 	logLevel: logLevels.debug,
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -203,7 +203,7 @@ declare namespace suitest {
 
 	interface ConfigureOptions {
 		logLevel?: 'silent'|'normal'|'verbose'|'debug';
-		useSentry?: boolean;
+		disallowCrashReports?: boolean;
 	}
 
 	interface ResponseError {

--- a/lib/testLauncher/commands/automated.js
+++ b/lib/testLauncher/commands/automated.js
@@ -46,8 +46,8 @@ const builder = yargs => {
 			default: 0,
 			global: false,
 		})
-		.option('use-sentry', {
-			describe: texts.cliUseSentry(),
+		.option('disallow-crash-reports', {
+			describe: texts.cliDisallowCrashReports(),
 			global: false,
 			type: 'boolean',
 		})

--- a/lib/testLauncher/commands/interactive.js
+++ b/lib/testLauncher/commands/interactive.js
@@ -51,8 +51,8 @@ const builder = yargs => {
 			describe: 'Will launch user command with --inspect-brk execArgv, used for debugging',
 			global: false,
 		})
-		.option('use-sentry', {
-			describe: texts.cliUseSentry(),
+		.option('disallow-crash-reports', {
+			describe: texts.cliDisallowCrashReports(),
 			global: false,
 			type: 'boolean',
 		})

--- a/lib/texts.js
+++ b/lib/texts.js
@@ -127,5 +127,5 @@ ${leaves}`,
 
 	// Cli args
 	cliLogLevel: () => 'Logger verbosity level',
-	cliUseSentry: () => 'Allow suitest to use Sentry error reporting',
+	cliDisallowCrashReports: () => 'Allow suitest to use Sentry error reporting',
 };

--- a/lib/texts.js
+++ b/lib/texts.js
@@ -26,7 +26,7 @@ module.exports = {
 	valueMustBeRepo: () => 'value is expected to be VALUE.REPO when matching against repository element',
 	recursionDetected: () => 'Recursive structure detected',
 
-	unknownError: () => 'Unknown Suitest error occurred. Our developers are notified if sentry option is turned on. If Error repeats, please contact us via support@suite.st.',
+	unknownError: () => 'Unknown Suitest error occurred. Our developers are notified if suitest allowed to submit automatic crash reports. If Error repeats, please contact us via support@suite.st.',
 	// Auth errors
 	authNotAllowed: commandName => `You're not allowed to execute .${commandName} function. Make sure you're logged in with the correct credentials.`,
 	authFailed: () => 'Authentication failed. Make sure you\'re trying to login with correct credentials.',
@@ -127,5 +127,5 @@ ${leaves}`,
 
 	// Cli args
 	cliLogLevel: () => 'Logger verbosity level',
-	cliDisallowCrashReports: () => 'Allow suitest to use Sentry error reporting',
+	cliDisallowCrashReports: () => 'Disallow Suitest to submit automatic crash reports when unexpected exceptions occur',
 };

--- a/lib/utils/sentry/Raven.js
+++ b/lib/utils/sentry/Raven.js
@@ -20,7 +20,7 @@ if (!isSetup) {
 			captureUnhandledRejections: false,
 			shouldSendCallback(data) {
 				// send report if enabled in config and only uncaught suitest api errors
-				return config.useSentry && isSuitestUncaughtError(data.exception[0]);
+				return !config.disallowCrashReports && isSuitestUncaughtError(data.exception[0]);
 			},
 		})
 		.install(err => {

--- a/lib/validataion/jsonSchemas.js
+++ b/lib/validataion/jsonSchemas.js
@@ -303,7 +303,7 @@ schemas[validationKeys.CONFIGURE] = {
 	'type': 'object',
 	'additionalProperties': false,
 	'properties': {
-		'useSentry': {'type': 'boolean'},
+		'disallowCrashReports': {'type': 'boolean'},
 		'logLevel': {'enum': ['silent', 'normal', 'verbose', 'debug']},
 	},
 };

--- a/lib/validataion/validators.js
+++ b/lib/validataion/validators.js
@@ -51,7 +51,7 @@ function prettifyJsonSchemaErrors(validate) {
 				return `Element property ${dataName.toString()} is unknown Symbol.`;
 			});
 	} else if (validate.schema.schemaId === validationKeys.CONFIGURE) {
-		// example: Invalid input provided for configuration object. 'useSentry' should be boolean.
+		// example: Invalid input provided for configuration object. 'disallowCrashReports' should be boolean.
 		errors = validate.errors.map(i => `'${i.dataPath.slice(1)}' ${i.message}.`);
 	} else {
 		errors = validate.errors.map(i => i.message);

--- a/test/commands/configure.test.js
+++ b/test/commands/configure.test.js
@@ -13,15 +13,15 @@ describe('confugure', () => {
 	});
 
 	it('should set config ovverride', async() => {
-		const defaultSentryUse = config.useSentry;
+		const defaultSentryUse = config.disallowCrashReports;
 
 		await configure({
-			useSentry: !defaultSentryUse,
+			disallowCrashReports: !defaultSentryUse,
 			logLevel: 'verbose',
 		});
 		assert.deepEqual(config, {
 			...config,
-			useSentry: !defaultSentryUse,
+			disallowCrashReports: !defaultSentryUse,
 			logLevel: 'verbose',
 		}, 'config updated');
 	});

--- a/test/utils/SuitestError.test.js
+++ b/test/utils/SuitestError.test.js
@@ -67,6 +67,6 @@ describe('SuitestError', () => {
 		const err = new SuitestError();
 
 		assert.equal(err.code, SuitestError.UNKNOWN_ERROR);
-		assert.equal(err.message, 'Unknown Suitest error occurred. Our developers are notified if sentry option is turned on. If Error repeats, please contact us via support@suite.st.');
+		assert.equal(err.message, 'Unknown Suitest error occurred. Our developers are notified if suitest allowed to submit automatic crash reports. If Error repeats, please contact us via support@suite.st.');
 	});
 });

--- a/test/validation/validators.test.js
+++ b/test/validation/validators.test.js
@@ -41,8 +41,8 @@ describe('validators', () => {
 	});
 
 	it('should throw correct error message', () => {
-		testInputErrorSync(validate, [validators.CONFIGURE, {useSentry: 'false'}], {
-			message: 'Invalid input \'useSentry\' should be boolean.',
+		testInputErrorSync(validate, [validators.CONFIGURE, {disallowCrashReports: 'false'}], {
+			message: 'Invalid input \'disallowCrashReports\' should be boolean.',
 		}, 'invalid configuration object');
 	});
 });


### PR DESCRIPTION
SUIT-9592 Update useSentry flag naming in JS API changed to disallowCrashReports