### PR TITLE
SUIT-9587 Add hint for command-specific help messages to JS API

### DIFF
--- a/lib/testLauncher/buildArgs.js
+++ b/lib/testLauncher/buildArgs.js
@@ -2,6 +2,7 @@ const yargs = require('yargs/yargs');
 const automatedCommand = require('./commands/automated');
 const interactiveCommand = require('./commands/interactive');
 const {version} = require('../../package.json');
+const {stColors} = require('./launcherLogger');
 
 /**
  * Build main argv
@@ -12,6 +13,7 @@ const buildYargs = () => {
 		.boolean('help')
 		.boolean('version')
 		.help(false)
+		.epilog(`Run ${stColors.bold('suitest interactive --help')} or ${stColors.bold('suitest automated --help')} to see those command's options`)
 		.version(false);
 };
 

--- a/lib/testLauncher/buildArgs.js
+++ b/lib/testLauncher/buildArgs.js
@@ -3,6 +3,7 @@ const automatedCommand = require('./commands/automated');
 const interactiveCommand = require('./commands/interactive');
 const {version} = require('../../package.json');
 const {stColors} = require('./launcherLogger');
+const texts = require('../texts');
 
 /**
  * Build main argv
@@ -13,7 +14,8 @@ const buildYargs = () => {
 		.boolean('help')
 		.boolean('version')
 		.help(false)
-		.epilog(`Run ${stColors.bold('suitest interactive --help')} or ${stColors.bold('suitest automated --help')} to see those command's options`)
+		.check((hash, argv) => !argv.length && stColors.errorColor(texts['tl.noArguments']()), false)
+		.epilog(texts['tl.seeMoreCommandsOptions'](stColors.bold('suitest interactive --help'), stColors.bold('suitest automated --help')))
 		.version(false);
 };
 

--- a/lib/texts.js
+++ b/lib/texts.js
@@ -121,6 +121,8 @@ ${leaves}`,
 
 	// test launcher
 	'tl.nodevices': () => 'there is no device in config to proceed with testing',
+	'tl.noArguments': () => 'Command was not specified',
+	'tl.seeMoreCommandsOptions': template`Run ${0} or ${1} to see those commands options`,
 	'tl.finishedWithErrors': () => 'Some executions finished with errors',
 	'tl.finishedWithSuccess': () => 'All executions finished successfully',
 	'tl.promptPassword': () => 'Please enter your passwod: ',


### PR DESCRIPTION
SUIT-9587
Add hint for command-specific help messages to JS API