### PR TITLE
SUIT-9758 Add info logs about failures

### DIFF
--- a/lib/api/webSockets.js
+++ b/lib/api/webSockets.js
@@ -75,7 +75,10 @@ function handleResponse(msg) {
 		} else if (res.result === 'success') {
 			req.resolve(res);
 		} else {
-			req.reject(new SuitestError(res.error ? res.error : '', SuitestError.UNKNOWN_ERROR));
+			const message = res.error ? res.error : texts.unknownError();
+
+			logger.info(texts['prefix.error']() + message);
+			req.reject(new SuitestError(message, SuitestError.UNKNOWN_ERROR));
 		}
 
 		delete requestPromises[messageId];

--- a/lib/texts.js
+++ b/lib/texts.js
@@ -214,7 +214,10 @@ ${leaves}`,
 	'errorType.landingActivityTimeoutError': template`We have waited for the requested activity to open, but instead the ${0} was started. Please check the configuration settings.`,
 	'errorType.videoAdapterError': template`Video adapter error: ${0}.`,
 
-	'response.result.fatal.prefix': () => 'Fatal. ',
+	// prefixes
+	'prefix.fatal': () => 'Fatal. ',
+	'prefix.assertionFailed': () => 'Assertion failed. ',
+	'prefix.error': () => 'Error. ',
 
 	// logger msg
 	commandExecuted: (name) => `command "${name}" was executed`,

--- a/lib/utils/socketChainHelper.js
+++ b/lib/utils/socketChainHelper.js
@@ -5,6 +5,8 @@ const SuitestError = require('../utils/SuitestError');
 const {ELEMENT_PROP} = require('../mappings');
 const {getErrorMessage} = require('./socketErrorMessages');
 const {config} = require('../../config');
+const logger = require('./logger');
+const t = require('../texts');
 
 const assertionErrorTypes = ['queryFailed', 'appRunning', 'appNotRunning', 'queryTimeout'];
 
@@ -23,6 +25,7 @@ const processServerResponse = toString => function processServerResponseHandler(
 
 	// fatal errors
 	if (res.result === 'fatal' && !config.continueOnFatalError) {
+		logger.info(message);
 		console.error(message);
 
 		return process.exit(1);
@@ -59,6 +62,7 @@ const processServerResponse = toString => function processServerResponseHandler(
 	if (res.result !== 'success' && res.contentType === 'testLine' && isAssertionError) {
 		const {actualValue, expectedValue} = getActualExpectedValues(res, data);
 
+		logger.info(t['prefix.assertionFailed']() + message);
 		throw new assert.AssertionError({
 			actual: actualValue,
 			expected: expectedValue,
@@ -67,6 +71,7 @@ const processServerResponse = toString => function processServerResponseHandler(
 		});
 	}
 
+	logger.info(t['prefix.error']() + message);
 	throw new SuitestError(message);
 };
 

--- a/lib/utils/socketErrorMessages.js
+++ b/lib/utils/socketErrorMessages.js
@@ -49,7 +49,7 @@ function defaultMessage({chainData, toString, response}) {
  * @returns {string}
  */
 function getErrorMessage({errorMap, chainData, toString, response}) {
-	const prefix = response.result === 'fatal' ? t['response.result.fatal.prefix']() : '';
+	const prefix = response.result === 'fatal' ? t['prefix.fatal']() : '';
 	const payload = {
 		chainData,
 		toString,

--- a/test/utils/socketErrorMessages.test.js
+++ b/test/utils/socketErrorMessages.test.js
@@ -123,6 +123,10 @@ describe('Socket error messages', () => {
 			[basePayload('unsupportedButton'), 'Specified buttons are not supported on this device. Chain description'],
 			[basePayload('aborted'), 'Test execution was aborted. Chain description'],
 			[
+				set(lensPath(['response', 'message', 'info', 'reason']), 'manualActionRequired', basePayload('aborted')),
+				'Manual actions are not supported.',
+			],
+			[
 				set(lensPath(['chainData']), {
 					type: 'press',
 					repeat: 4,


### PR DESCRIPTION
Added info logs when something fails, so they are displayed in real time when running tests with test runner like mocha.