### PR TITLE
Add code climate duplication plugin

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -39,4 +39,4 @@ plugins:
     config:
       languages:
         javascript:
-          mass_threshold: 65
+          mass_threshold: 75

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -34,3 +34,9 @@ plugins:
   eslint:
     enabled: true
     channel: "eslint-4"
+  duplication:
+    enabled: true
+    config:
+      languages:
+        javascript:
+          mass_threshold: 75

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -39,4 +39,4 @@ plugins:
     config:
       languages:
         javascript:
-          mass_threshold: 75
+          mass_threshold: 65


### PR DESCRIPTION
This should make duplication detection smarter. For example CC should not complain about `module.exports` being duplicated in every file.