### PR TITLE
SUIT-11909 Rename cli option config to configFile to avoid conflicts with rc module

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -47,7 +47,7 @@ const configFields = [
 const launcherFields = [
 	'tokenKey', 'tokenPassword', 'testPackId', 'concurrency', // launcher automated
 	'username', 'password', 'orgId', 'deviceId', 'appConfigId', 'inspect', 'inspectBrk', // launcher intaractive
-	'logDir', 'timestamp', 'config', // launcher common
+	'logDir', 'timestamp', 'configFile', // launcher common
 ];
 const allFields = [...configFields.map(({name}) => name), ...launcherFields];
 

--- a/lib/testLauncher/commands/automated.js
+++ b/lib/testLauncher/commands/automated.js
@@ -47,7 +47,7 @@ const builder = yargs => {
 };
 
 const handler = async(argv) => {
-	const userConfig = argv.config ? readUserConfig(argv.config) : {};
+	const userConfig = argv.configFile ? readUserConfig(argv.configFile) : {};
 	const ownArgs = mergeConfigs(mergeConfigs(launcherParams, userConfig), argv);
 
 	override(ownArgs);

--- a/lib/testLauncher/commands/common.js
+++ b/lib/testLauncher/commands/common.js
@@ -7,7 +7,7 @@ const logLevels = require('../../constants/logLevels');
  */
 function applyCommonArgs(yargs) {
 	yargs
-		.option('config', {
+		.option('config-file', {
 			describe: texts.cliConfig(),
 			global: false,
 			type: 'string',

--- a/lib/testLauncher/commands/interactive.js
+++ b/lib/testLauncher/commands/interactive.js
@@ -4,7 +4,7 @@
 const {promptPassword, mergeConfigs} = require('../../utils/testLauncherHelper');
 const SuitestLauncher = require('../SuitestLauncher');
 const {hideOwnArgs} = require('../processArgs');
-const {launcherParams, override, readUserConfig, config} = require('../../../config');
+const {launcherParams, override, readUserConfig} = require('../../../config');
 const {applyCommonArgs} = require('./common');
 
 const command = 'interactive';
@@ -52,7 +52,7 @@ const builder = yargs => {
 };
 
 const handler = async(argv) => {
-	const userConfig = argv.config ? readUserConfig(argv.config) : {};
+	const userConfig = argv.configFile ? readUserConfig(argv.configFile) : {};
 	const ownArgs = mergeConfigs(mergeConfigs(launcherParams, userConfig), argv);
 
 	ownArgs.password = ownArgs.password || await promptPassword();

--- a/lib/validataion/jsonSchemas.js
+++ b/lib/validataion/jsonSchemas.js
@@ -356,7 +356,7 @@ schemas[validationKeys.CONFIGURE] = {
 	'properties': {
 		'appConfigId': {'type': 'string'},
 		'concurrency': {'type': 'number'},
-		'config': {'type': 'string'},
+		'configFile': {'type': 'string'},
 		'continueOnFatalError': {'type': 'boolean'},
 		'deviceId': {'type': 'string'},
 		'disallowCrashReports': {'type': 'boolean'},


### PR DESCRIPTION
Rc module adds 'config' field to object it returns. This field describes path to the .rc file it founds and uses. It was conflicting with our '--config' cli option, so we decided to rename it.