### PR TITLE
SUIT-12239 Increase process stdout max listeners

### DIFF
--- a/lib/testLauncher/SuitestLauncher.js
+++ b/lib/testLauncher/SuitestLauncher.js
@@ -58,8 +58,8 @@ class SuitestLauncher {
 			});
 
 			addLauncherIpcListeners();
-			// increase stdout max listeners based on number of devices to avoid node warning
-			increaseMaxListeners(process.stdout, devices.length * 2);
+			// increase stdout max listeners based on number of child processes to avoid node warning
+			increaseMaxListeners(process.stdout, devices.length, this.ownArgv.concurrency);
 
 			try {
 				await runAllDevices(

--- a/lib/testLauncher/SuitestLauncher.js
+++ b/lib/testLauncher/SuitestLauncher.js
@@ -9,6 +9,7 @@ const {
 	getDebugPort,
 	addLauncherIpcListeners,
 	throwDebugInAutomatedError,
+	increaseMaxListeners,
 } = require('../utils/testLauncherHelper');
 const {AUTOMATED, INTERACTIVE, TEST_COMMAND} = require('../constants/modes');
 const {getDevicesDetails} = require('../utils/getDeviceInfo');
@@ -57,6 +58,8 @@ class SuitestLauncher {
 			});
 
 			addLauncherIpcListeners();
+			// increase stdout max listeners based on number of devices to avoid node warning
+			increaseMaxListeners(process.stdout, devices.length * 2);
 
 			try {
 				await runAllDevices(

--- a/lib/utils/testLauncherHelper.js
+++ b/lib/utils/testLauncherHelper.js
@@ -409,13 +409,16 @@ async function getVersion() {
 }
 
 /**
- * Increase event emitter max allowed listeners count by some number
+ * Increase event emitter max allowed listeners count by 2 per child thread
  * @param {EventEmitter} emitter
- * @param {number} byNum
+ * @param {number} deviceCount
+ * @param {number} concurrency
  * @modifies emitter
  */
-function increaseMaxListeners(emitter, byNum) {
-	emitter.setMaxListeners(emitter.getMaxListeners() + byNum);
+function increaseMaxListeners(emitter, deviceCount, concurrency) {
+	const threadCount = concurrency === 0 ? deviceCount : Math.min(concurrency, deviceCount);
+
+	emitter.setMaxListeners(emitter.getMaxListeners() + threadCount * 2);
 }
 
 module.exports = {

--- a/lib/utils/testLauncherHelper.js
+++ b/lib/utils/testLauncherHelper.js
@@ -408,6 +408,16 @@ async function getVersion() {
 	return suitestVersion;
 }
 
+/**
+ * Increaet event emitter max allowed listeners count by some number
+ * @param {EventEmitter} emitter
+ * @param {number} byNum
+ * @modifies emitter
+ */
+function increaseMaxListeners(emitter, byNum) {
+	emitter.setMaxListeners(emitter.getMaxListeners() + byNum);
+}
+
 module.exports = {
 	handleLauncherError,
 	handleChildResult,
@@ -421,4 +431,5 @@ module.exports = {
 	getDebugPort,
 	addLauncherIpcListeners,
 	throwDebugInAutomatedError,
+	increaseMaxListeners,
 };

--- a/lib/utils/testLauncherHelper.js
+++ b/lib/utils/testLauncherHelper.js
@@ -409,7 +409,7 @@ async function getVersion() {
 }
 
 /**
- * Increaet event emitter max allowed listeners count by some number
+ * Increase event emitter max allowed listeners count by some number
  * @param {EventEmitter} emitter
  * @param {number} byNum
  * @modifies emitter

--- a/test/utils/testLauncherHelper.test.js
+++ b/test/utils/testLauncherHelper.test.js
@@ -64,11 +64,25 @@ describe('testLauncherHelper util', () => {
 	});
 
 	it('should increaseMaxListeners correctly', () => {
-		const emitter = new EventEmitter();
-		const listenersCount = emitter.getMaxListeners();
+		const emitter1 = new EventEmitter();
+		const listenersCount1 = emitter1.getMaxListeners();
 
-		testLauncherHelper.increaseMaxListeners(emitter, 5);
+		testLauncherHelper.increaseMaxListeners(emitter1, 5, 3);
 
-		assert.strictEqual(emitter.getMaxListeners(), listenersCount + 5);
+		assert.strictEqual(emitter1.getMaxListeners(), listenersCount1 + 6, 'when devicesCount > concurrency allowed, limit to concurrency');
+
+		const emitter2 = new EventEmitter();
+		const listenersCount2 = emitter2.getMaxListeners();
+
+		testLauncherHelper.increaseMaxListeners(emitter2, 5, 0);
+
+		assert.strictEqual(emitter2.getMaxListeners(), listenersCount2 + 10, 'when concurrency is 0, limit to devicesCount');
+
+		const emitter3 = new EventEmitter();
+		const listenersCount3 = emitter3.getMaxListeners();
+
+		testLauncherHelper.increaseMaxListeners(emitter3, 5, 10);
+
+		assert.strictEqual(emitter3.getMaxListeners(), listenersCount3 + 10, 'when devicesCount < concurrency, limit to devicesCount');
 	});
 });

--- a/test/utils/testLauncherHelper.test.js
+++ b/test/utils/testLauncherHelper.test.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const sinon = require('sinon');
 const validation = require('../../lib/validataion');
+const EventEmitter = require('events');
 
 const SuitestError = require('../../lib/utils/SuitestError');
 const {snippets: log} = require('../../lib/testLauncher/launcherLogger');
@@ -60,5 +61,14 @@ describe('testLauncherHelper util', () => {
 		assert.ok(argsValidationError.firstCall.args[0].message.includes('Invalid input'));
 		assert.ok(process.exit.calledWith(1), 'exit called with 1');
 		argsValidationError.restore();
+	});
+
+	it('should increaseMaxListeners correctly', () => {
+		const emitter = new EventEmitter();
+		const listenersCount = emitter.getMaxListeners();
+
+		testLauncherHelper.increaseMaxListeners(emitter, 5);
+
+		assert.strictEqual(emitter.getMaxListeners(), listenersCount + 5);
 	});
 });


### PR DESCRIPTION
Explicitly increase process stdout max listeners based on number of devices (we need 2 per device) in automated test run to avoid node MaxListenersExceededWarning warning. 