### PR TITLE
SUIT-13164 Do not cut stack trace in JS API when running in debug mode.

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -8,9 +8,6 @@
 
 const logLevels = require('../lib/constants/logLevels');
 const timestamp = require('../lib/constants/timestamp');
-const {validate, validators} = require('../lib/validataion');
-const {invalidConfigObj} = require('../lib/texts');
-const {pickNonNil} = require('../lib/utils/common');
 
 const sentryDsn = 'https://1f74b885d0c44549b57f307733d60351:dd736ff3ac994104ab6635da53d9be2e@sentry.io/288812';
 const DEFAULT_TIMEOUT = 2000;
@@ -46,17 +43,6 @@ const test = Object.freeze({
 const config = {...(global._suitestTesting ? test : main)};
 
 /**
- * Override config object
- * @param {Object} overrideObj
- */
-function override(overrideObj = {}) {
-	const _overrideObj = pickNonNil(overridableFields, overrideObj);
-
-	validate(validators.CONFIGURE, _overrideObj, invalidConfigObj());
-	extend(_overrideObj);
-}
-
-/**
  * Override config directly without user input validation
  * Not to be used for user input
  * @param ext
@@ -67,7 +53,6 @@ function extend(ext) {
 
 module.exports = {
 	config,
-	override,
 	overridableFields,
 	extend,
 };

--- a/config/override.js
+++ b/config/override.js
@@ -1,0 +1,19 @@
+const {extend, overridableFields} = require('./index');
+const {validate, validators} = require('../lib/validataion');
+const {invalidConfigObj} = require('../lib/texts');
+const {pickNonNil} = require('../lib/utils/common');
+
+/**
+ * Override config object
+ * @param {Object} overrideObj
+ */
+function override(overrideObj = {}) {
+	const _overrideObj = pickNonNil(overridableFields, overrideObj);
+
+	validate(validators.CONFIGURE, _overrideObj, invalidConfigObj());
+	extend(_overrideObj);
+}
+
+module.exports = {
+	override,
+};

--- a/lib/commands/configure.js
+++ b/lib/commands/configure.js
@@ -2,7 +2,7 @@
  * Suitest method to override main config.
  */
 const util = require('util');
-const {override} = require('../../config');
+const {override} = require('../../config/override');
 const chainPromise = require('../utils/chainPromise');
 const {warnConfigureDeprecation} = require('../texts');
 

--- a/lib/testLauncher/commands/automated.js
+++ b/lib/testLauncher/commands/automated.js
@@ -3,7 +3,7 @@
  */
 
 const SuitestLauncher = require('../SuitestLauncher');
-const {override} = require('../../../config');
+const {override} = require('../../../config/override');
 const {applyCommonArgs} = require('./common');
 const {once} = require('ramda');
 const {composeConfig} = require('../composeConfig');

--- a/lib/testLauncher/commands/interactive.js
+++ b/lib/testLauncher/commands/interactive.js
@@ -2,7 +2,7 @@
  * 'interactive' test launcher command
  */
 const SuitestLauncher = require('../SuitestLauncher');
-const {override} = require('../../../config');
+const {override} = require('../../../config/override');
 const {applyCommonArgs} = require('./common');
 const {once} = require('ramda');
 const {composeConfig} = require('../composeConfig');

--- a/lib/utils/SuitestError.js
+++ b/lib/utils/SuitestError.js
@@ -11,6 +11,8 @@
 
 const {fetchSource, stripSuitestCodeFromStack} = require('./stackTraceParser');
 const {unknownError} = require('./../texts');
+const {config} = require('../../config');
+const logLevels = require('../constants/logLevels');
 
 const suitestErrorType = 'SuitestError';
 
@@ -25,7 +27,7 @@ class SuitestError extends Error {
 			this.message = unknownError();
 		}
 
-		this.stack = stripSuitestCodeFromStack(this.stack);
+		this.stack = config.logLevel === logLevels.debug ? this.stack : stripSuitestCodeFromStack(this.stack);
 
 		if (causedBy instanceof Error)
 			this.causedBy = causedBy;

--- a/lib/utils/stackTraceParser.js
+++ b/lib/utils/stackTraceParser.js
@@ -4,6 +4,8 @@ const escapeRegexp = require('escape-string-regexp');
 
 const isSuitestMethod = require('./isSuitestMethod');
 const {failedStackTrace} = require('../texts');
+const {config} = require('../../config');
+const logLevels = require('../constants/logLevels');
 
 /**
  * Fetch source code from stack trace frame
@@ -71,7 +73,7 @@ function getStackLines(stack, filterFunc = i => i) {
 }
 
 /**
- * Filter out suitest api related code lines fron error stack
+ * Filter out suitest api related code lines from error stack
  * @param {string} stack error stack
  * @returns {string}
  */
@@ -94,13 +96,16 @@ function stripAbsolutePaths(stack) {
  * Prepend error stack with another one, excluding duplicated lines
  * @param {string} stackA
  * @param {string} stackB
+ * @param {boolean} [includeSuitestLines]
  * @returns {string}
  */
-function prependStack(stackA, stackB) {
+function prependStack(stackA, stackB, includeSuitestLines = false) {
 	const oldLines = getStackLines(stackA);
 	const newLines = getStackLines(stackB, l => !oldLines.includes(l));
 
-	return stripAbsolutePaths(stripSuitestCodeFromStack(stackA.replace(
+	const stackProcessor = includeSuitestLines ? stack => stack : stripSuitestCodeFromStack;
+
+	return stripAbsolutePaths(stackProcessor(stackA.replace(
 		oldLines,
 		newLines + (newLines.length ? '\n' : '') + oldLines),
 	));
@@ -129,7 +134,7 @@ const stackTraceWrapper = fn => {
 		try {
 			return await fn(...args);
 		} catch (error) {
-			error.stack = prependStack(error.stack, stack);
+			error.stack = prependStack(error.stack, stack, config.logLevel === logLevels.debug);
 			throw error;
 		}
 	};

--- a/test/commands/configure.test.js
+++ b/test/commands/configure.test.js
@@ -2,7 +2,8 @@ const assert = require('assert');
 const sinon = require('sinon');
 
 const configure = require('../../lib/commands/configure');
-const {config, override} = require('../../config');
+const {config} = require('../../config');
+const {override} = require('../../config/override');
 const logger = require('../../lib/utils/logger');
 
 const cachedConfig = {...config};
@@ -23,7 +24,7 @@ describe('confugure', () => {
 			continueOnFatalError: true,
 			logLevel: 'verbose',
 		});
-		assert.deepEqual(config, {
+		assert.deepStrictEqual(config, {
 			...config,
 			disallowCrashReports: true,
 			continueOnFatalError: true,


### PR DESCRIPTION
Moved override config function to separate file for resolving circular dependency between config.js and SuitestError.js