### PR TITLE
Hotfix/suit 13956 run test with line results

### DIFF
--- a/lib/api/endpoints.js
+++ b/lib/api/endpoints.js
@@ -16,7 +16,7 @@ const endpoints = {
 	appTestPacks:          '/apps/:appId/test-packs',
 	appTestPackById:       '/apps/:appId/test-packs/:testPackId',
 	appTestDefinitions:    '/apps/:appId/test-definitions',
-	appTestDefinitionById: '/apps/:appId/test-definitions/:testDefinitionId',
+	appTestDefinitionById: '/apps/:appId/versions/:versionId/tests/:testId',
 	devices:               '/devices',
 	testRun:               '/test-run',
 	testRunById:           '/test-run/:testRunId',

--- a/lib/api/request.js
+++ b/lib/api/request.js
@@ -14,7 +14,7 @@ const {suitestServerError} = require('../texts');
  *
  * @param {string|[string, any]} url
  * @param {Object|any} requestObject
- * @param {Function} onReject - will be invoked if response not ok
+ * @param {Function} [onReject] - will be invoked if response not ok
  * @returns {Promise}
  */
 function request(url, requestObject, onReject) {

--- a/lib/chains/runTestChain.js
+++ b/lib/chains/runTestChain.js
@@ -1,4 +1,8 @@
-const {compose} = require('ramda');
+const {compose, uniq} = require('ramda');
+const {authContext, appContext} = require('../context');
+const endpoints = require('../api/endpoints');
+const request = require('../api/request');
+const colors = require('colors');
 
 // Import utils
 const makeChain = require('../utils/makeChain');
@@ -15,7 +19,10 @@ const {
 	untilComposer,
 } = require('../composers');
 const {
-	runTest,
+	runTestStart,
+	runTestWithChanges,
+	runTestEnd,
+	runTestLoopCount,
 	chainRepeat,
 	invalidInputMessage,
 } = require('../texts');
@@ -27,11 +34,12 @@ const {
 	applyUntilCondition,
 } = require('../utils/socketChainHelper');
 const logger = require('../utils/logger');
-const getOpType = require('../utils/opType').getOpType;
+
+const chainName = 'runTest';
 
 const toString = data => {
 	const repeat = data.repeat;
-	let out = runTest(data.testId);
+	let out = runTestStart(data.val || data.testId); // TODO: use val when we can translate jsons
 
 	if (repeat) {
 		out += chainRepeat(repeat);
@@ -39,7 +47,6 @@ const toString = data => {
 
 	return out;
 };
-const beforeSendMsg = (data) => logger.log(getOpType(data), toString(data));
 
 const toJSON = (data) => ({
 	type: getRequestType(data, false),
@@ -53,7 +60,137 @@ const toJSON = (data) => ({
 });
 
 const toStringComposer = makeToStringComposer(toString);
-const thenComposer = makeThenComposer(toJSON, processServerResponse(toString), beforeSendMsg);
+
+const logLine = msg => logger.log('|A|', msg);
+
+// TODO: replace these with real translation functions
+const translateLine = lineDef => lineDef.type === 'runSnippet' ? toString(lineDef) : lineDef.type;
+const translateError = lineDef => colors.red(translateLine(lineDef));
+const translateLineResult = (lineDef, response) => {
+	return response.result === 'success' ? translateLine(lineDef) : translateError(lineDef);
+};
+
+/**
+ * Get snippet lines output recursively
+ * @param {Object} data
+ * @param {string} data.testId - id of root test
+ * @param {Object} data.definitions - test definitions by id
+ * @param {Array} data.results - results for current runSnippet line
+ * @param {boolean} data.withChanges - include changes or not
+ * @param {number} data.level - level for indentation, initially 1
+ * @param {(line, result) => string} data.translateResult - function to translate line results
+ */
+const getSnippetLogs = ({testId, definitions, results, withChanges, level, translateResult}) => {
+	const indent = ' '.repeat(4 * level);
+
+	return results.reduce((logs, res) => {
+		const idx = res.lineId.split('-').map(Number)[level] - 1;
+		const line = definitions[testId][idx];
+
+		logs.push(indent + translateResult(line, res));
+
+		if (res.results || res.loopResults) {
+			const getLoopLogs = loopRes => getSnippetLogs({
+				testId: line.val,
+				definitions,
+				results: loopRes,
+				withChanges,
+				level: level + 1,
+				translateResult,
+			});
+
+			logs.push(indent + runTestWithChanges(withChanges));
+			if (res.loopResults) {
+				res.loopResults.forEach((loop, idx) => {
+					logs.push(indent + runTestLoopCount(idx + 1));
+					logs.push(...getLoopLogs(loop.results));
+				});
+			} else {
+				logs.push(...getLoopLogs(res.results));
+			}
+			logs.push(indent + runTestEnd(line.val));
+		}
+
+		return logs;
+	}, []);
+};
+
+/**
+ * Fetch test definitions recursively for all snippet lines
+ * @param {string} appId
+ * @param {string} versionId
+ * @param {string} testId
+ * @param {boolean} includeChangelist
+ */
+const fetchTestDefinitions = async(appId, versionId, testId, includeChangelist) => {
+	const authedRequestObject = await authContext.authorizeHttp(
+		endpoints.appTestDefinitionById,
+		{method: 'GET'},
+		{commandName: chainName}
+	);
+
+	const testDefinitionsById = {};
+
+	const fetchSingleTest = async(testId) => {
+		const {definition} = await request(
+			[
+				`${endpoints.appTestDefinitionById}?includeChangelist=${includeChangelist}`,
+				{appId, versionId, testId},
+			],
+			authedRequestObject
+		);
+
+		testDefinitionsById[testId] = definition;
+
+		const snippetsToFetch = uniq(
+			definition
+				.filter(line => line.type === 'runSnippet'
+					&& line.val
+					&& !line.excluded
+					&& !testDefinitionsById.hasOwnProperty(line.val)
+				)
+				.map(line => line.val)
+		);
+
+		await Promise.all(snippetsToFetch.map(fetchSingleTest));
+	};
+
+	await fetchSingleTest(testId);
+
+	return testDefinitionsById;
+};
+
+const thenComposer = (...args) => {
+	const isInteractiveSession = authContext.isInteractiveSession();
+	let testDefinitionPromise;
+
+	const before = async(data) => {
+		const {appId, versionId} = appContext.context;
+		const {testId} = data;
+
+		logLine(translateLine(toJSON(data).request));
+		logLine(runTestWithChanges(isInteractiveSession));
+		testDefinitionPromise = fetchTestDefinitions(appId, versionId, testId, isInteractiveSession);
+	};
+
+	const after = async(res, data) => {
+		const testDefinitionsById = await testDefinitionPromise;
+
+		getSnippetLogs({
+			testId: data.testId,
+			definitions: testDefinitionsById,
+			results: res.results,
+			withChanges: isInteractiveSession,
+			level: 1,
+			translateResult: translateLineResult,
+		}).forEach(logLine);
+		logLine(runTestEnd(data.testId));
+		processServerResponse(toString)(res, data);
+	};
+
+	return makeThenComposer(toJSON, after, before)(...args);
+};
+
 const toJSONComposer = makeToJSONComposer(toJSON);
 
 const getComposers = data => {
@@ -86,7 +223,7 @@ const getComposers = data => {
 
 const runTestChain = testId => makeChain(getComposers, {
 	type: 'runSnippet',
-	testId: validate(validators.NON_EMPTY_STRING, testId, invalidInputMessage('runTest', 'Test ID')),
+	testId: validate(validators.NON_EMPTY_STRING, testId, invalidInputMessage(chainName, 'Test ID')),
 });
 
 module.exports = {
@@ -95,5 +232,6 @@ module.exports = {
 	// For testing
 	runTest: runTestChain,
 	toJSON,
-	beforeSendMsg,
+	getSnippetLogs,
+	fetchTestDefinitions,
 };

--- a/lib/commands/setAppConfig.js
+++ b/lib/commands/setAppConfig.js
@@ -34,10 +34,12 @@ async function setAppConfig(configId, configOverride = {}) {
 	}, setAppConfig.name);
 
 	// make ws request
-	await webSockets.send(authedContent);
+	const {appId, versionId} = await webSockets.send(authedContent);
 
 	// set app context
 	appContext.setContext({
+		appId,
+		versionId,
 		configId,
 		configOverride,
 	});

--- a/lib/texts.js
+++ b/lib/texts.js
@@ -71,7 +71,6 @@ module.exports = {
 	sleep: template`Sleeping for ${0}ms`,
 
 	pressButton: template`Pressing button${1} ${0}`,
-	runTest: template`Running test by ID "${0}"`,
 
 	clearAppData: () => 'Cleared app data',
 
@@ -319,7 +318,6 @@ ${leaves}`,
 	'errorType.bootstrapAppNotDetected': () => 'The Suitest bootstrap application was not detected.',
 	'errorType.activationExpired': () => 'Could not open the app because the DevKit/TestKit expired.',
 	'errorType.missingCpp': () => 'Make sure you have Microsoft Visual C++ Redistributable installed. Please see our docs - https://suite.st/docs/devices/playstation.',
-	'errorType.testSnippetError': template`Test run by ID "${0}" failed.`,
 	'errorType.snippetInvalidReference': template`Test with ID "${0}" does not exist.`,
 
 	unknownServerError: template`Unknown server error occurred. Please forward this message to support@suite.st so they could fix it:\nCHAIN DATA:\n${0}\nRESPONSE:\n${1}.`,
@@ -404,4 +402,10 @@ ${leaves}`,
 	defaultTimeout: () => 'Globally set timeout value in milliseconds. Equals to 2000 when left out.',
 	cliTimestamp: () => `Logger timestamp format. Use "${timestamp.none}" to disable. [default: "${timestamp.default}"]. This string is processed with momentJS.`,
 	cliConfig: () => 'Config file to override default config.',
+
+	// Run test line
+	runTestStart: testId => `Running test by ID "${testId}"`,
+	runTestWithChanges: includeChangeList => `- with${includeChangeList ? '' : 'out'} version unapplied changes`,
+	runTestEnd: testId => `end of "${testId}" test`,
+	runTestLoopCount: count => `- loop count: ${count}`,
 };

--- a/lib/utils/socketErrorMessages.js
+++ b/lib/utils/socketErrorMessages.js
@@ -638,9 +638,7 @@ const errorMap = {
 	bootstrapAppNotDetected: () => t['errorType.bootstrapAppNotDetected'](),
 	activationExpired: () => t['errorType.activationExpired'](),
 	missingCpp: () => t['errorType.missingCpp'](),
-	testSnippetError: ({chainData}) => {
-		return t['errorType.testSnippetError'](chainData.testId);
-	},
+	testSnippetError: ({chainData, toString}) => toString(chainData),
 	invalidReference: ({chainData}) => {
 		return t['errorType.snippetInvalidReference'](chainData.testId);
 	},

--- a/lib/utils/testHelpers/mockWebSocket.js
+++ b/lib/utils/testHelpers/mockWebSocket.js
@@ -12,7 +12,8 @@ const mock = require('mock-require');
 
 let ws = null,
 	requestPromises = {},
-	connectionPromise = null;
+	connectionPromise = null,
+	mockedResponse;
 
 /**
  * Mocked connect to ws server
@@ -57,6 +58,12 @@ function handleResponse(msg) {
 	const messageId = msg.messageId;
 	const res = msg.content.response || msg.content;
 	const req = requestPromises[messageId];
+
+	if (mockedResponse) {
+		req.resolve(mockedResponse);
+
+		return;
+	}
 
 	/* istanbul ignore else */
 	if (req) {
@@ -142,3 +149,18 @@ mock('../../api/webSockets', {
 	send,
 	isConnected,
 });
+
+/**
+ * Mock WS response
+ */
+function mockResponse(resp) {
+	mockedResponse = resp;
+}
+function restoreResponse() {
+	mockedResponse = undefined;
+}
+
+module.exports = {
+	mockResponse,
+	restoreResponse,
+};

--- a/test/chains/runTestChain.test.js
+++ b/test/chains/runTestChain.test.js
@@ -1,14 +1,73 @@
+const nock = require('nock');
 const assert = require('assert');
-const {testInputErrorSync} = require('../../lib/utils/testHelpers/testInputError');
+const {config} = require('../../config');
 const {
 	runTest,
 	runTestAssert,
 	toJSON,
-	beforeSendMsg,
+	getSnippetLogs,
+	fetchTestDefinitions,
 } = require('../../lib/chains/runTestChain');
-const sinon = require('sinon');
+const {authContext} = require('../../lib/context');
+const endpoints = require('../../lib/api/endpoints');
+const testServer = require('../../lib/utils/testServer');
+const SuitestError = require('../../lib/utils/SuitestError');
+const sessionConstants = require('../../lib/constants/session');
+const makeUrlFromArray = require('../../lib/utils/makeUrlFromArray');
+const assertThrowsAsync = require('../../lib/utils/assertThrowsAsync');
+const {testInputErrorSync} = require('../../lib/utils/testHelpers/testInputError');
+
+const definitionsById = {
+	'test1': [{
+		type: 'openApp', // openApp are not present in results
+	}, {
+		type: 'sleep',
+	}, {
+		type: 'runSnippet',
+		val: 'test2',
+	}],
+	'test2': [{
+		type: 'openApp',
+	}, {
+		type: 'sleep',
+	}, {
+		type: 'runSnippet',
+		val: 'test3',
+	}, {
+		type: 'runSnippet',
+		val: 'test3',
+	}, {
+		type: 'sleep',
+	}],
+	'test3': [{
+		type: 'openApp',
+	}, {
+		type: 'sleep',
+	}, {
+		type: 'sleep',
+		excluded: true, // this flag does not matter, line will not be present in results
+	}, {
+		type: 'assert',
+	}, {
+		type: 'sleep',
+	}],
+};
 
 describe('Run test chain', () => {
+	before(async() => {
+		await testServer.start();
+	});
+
+	beforeEach(() => {
+		authContext.clear();
+	});
+
+	after(async() => {
+		nock.cleanAll();
+		authContext.clear();
+		await testServer.stop();
+	});
+
 	it('should have all necessary modifiers', () => {
 		const chain = runTest('testID');
 
@@ -59,14 +118,6 @@ describe('Run test chain', () => {
 		);
 	});
 
-	it('should have beforeSendMsg', () => {
-		const log = sinon.stub(console, 'log');
-
-		beforeSendMsg({type: 'testLine'});
-		assert.ok(log.firstCall.args[0], 'beforeSendMsg exists');
-		log.restore();
-	});
-
 	it('should throw error in case of invalid input', () => {
 		testInputErrorSync(runTest, []);
 		testInputErrorSync(runTest, ['']);
@@ -94,5 +145,157 @@ describe('Run test chain', () => {
 		assert.ok('then' in chain);
 		assert.ok('clone' in chain);
 		assert.ok('abandon' in chain);
+	});
+
+	describe('getSnippetLogs method', () => {
+		it('should produce correct output', () => {
+			const rootResults = [{
+				result: 'success',
+				lineId: '2-2',
+			}, {
+				result: 'fail',
+				lineId: '2-3',
+				results: [{
+					result: 'success',
+					lineId: '2-3-2',
+				}, {
+					result: 'fail',
+					lineId: '2-3-3',
+					loopResults: [{
+						results: [{
+							result: 'success',
+							lineId: '2-3-3-2',
+						}, {
+							result: 'success',
+							lineId: '2-3-3-4',
+						}, {
+							result: 'success',
+							lineId: '2-3-3-5',
+						}],
+					}, {
+						results: [{
+							result: 'success',
+							lineId: '2-3-3-2',
+						}, {
+							result: 'success',
+							lineId: '2-3-3-4',
+						}, {
+							result: 'fail',
+							lineId: '2-3-3-5',
+						}],
+					}],
+				}, {
+					result: 'success',
+					lineId: '2-3-4',
+					loopResults: [{
+						results: [{
+							result: 'success',
+							lineId: '2-3-4-2',
+						}, {
+							result: 'success',
+							lineId: '2-3-4-4',
+						}, {
+							result: 'success',
+							lineId: '2-3-4-5',
+						}],
+					}, {
+						results: [{
+							result: 'success',
+							lineId: '2-3-4-2',
+						}, {
+							result: 'success',
+							lineId: '2-3-4-4',
+						}, {
+							result: 'success',
+							lineId: '2-3-4-5',
+						}],
+					}],
+				}, {
+					result: 'success',
+					lineId: '2-3-5',
+				}],
+			}];
+
+			const translate = (line, res) => `${line.type}: ${res.result}`;
+
+			assert.deepStrictEqual(
+				getSnippetLogs({
+					testId: 'test1',
+					definitions: definitionsById,
+					results: rootResults,
+					withChanges: true,
+					level: 1,
+					translateResult: translate,
+				}),
+				[
+					'    sleep: success',
+					'    runSnippet: fail',
+					'    - with version unapplied changes',
+					'        sleep: success',
+					'        runSnippet: fail',
+					'        - with version unapplied changes',
+					'        - loop count: 1',
+					'            sleep: success',
+					'            assert: success',
+					'            sleep: success',
+					'        - loop count: 2',
+					'            sleep: success',
+					'            assert: success',
+					'            sleep: fail',
+					'        end of "test3" test',
+					'        runSnippet: success',
+					'        - with version unapplied changes',
+					'        - loop count: 1',
+					'            sleep: success',
+					'            assert: success',
+					'            sleep: success',
+					'        - loop count: 2',
+					'            sleep: success',
+					'            assert: success',
+					'            sleep: success',
+					'        end of "test3" test',
+					'        sleep: success',
+					'    end of "test2" test',
+				],
+			);
+		});
+	});
+
+	describe('fetchTestDefinitions method', () => {
+		const formUrl = testId => makeUrlFromArray([endpoints.appTestDefinitionById, {
+			appId: 'appId',
+			versionId: 'versionId',
+			testId,
+		}]) + '?includeChangelist=true';
+
+		const args = ['appId', 'versionId', 'testId', true];
+
+		it('should fail with proper error if auth context is not set', async() => {
+			await assertThrowsAsync(
+				() => fetchTestDefinitions(...args),
+				err => err.code === SuitestError.AUTH_NOT_ALLOWED,
+			);
+		});
+
+		it('should fail with proper network', async() => {
+			nock(config.apiUrl).get(formUrl('testId')).reply(404);
+			authContext.setContext(sessionConstants.INTERACTIVE, 'tokenId', 'tokenPass');
+
+			await assertThrowsAsync(
+				() => fetchTestDefinitions(...args),
+				err => err.code === SuitestError.SERVER_ERROR,
+			);
+		});
+
+		it('should return proper test definitons without duplicated test calls', async() => {
+			nock(config.apiUrl).get(formUrl('test1')).reply(200, {definition: definitionsById.test1});
+			nock(config.apiUrl).get(formUrl('test2')).reply(200, {definition: definitionsById.test2});
+			nock(config.apiUrl).get(formUrl('test3')).reply(200, {definition: definitionsById.test3});
+			authContext.setContext(sessionConstants.INTERACTIVE, 'tokenId', 'tokenPass');
+
+			const resp = await fetchTestDefinitions('appId', 'versionId', 'test1', true);
+
+			assert.deepStrictEqual(resp, definitionsById);
+		});
 	});
 });

--- a/test/commands/setAppConfig.test.js
+++ b/test/commands/setAppConfig.test.js
@@ -8,6 +8,7 @@ const sessionConstants = require('../../lib/constants/session');
 const {setAppConfig} = require('../../lib/commands/setAppConfig');
 const SuitestError = require('../../lib/utils/SuitestError');
 const webSockets = require('../../lib/api/webSockets');
+const mockWebSocket = require('../../lib/utils/testHelpers/mockWebSocket');
 const {testInputErrorAsync} = require('../../lib/utils/testHelpers/testInputError');
 const logger = require('../../lib/utils/logger');
 
@@ -19,10 +20,16 @@ describe('setAppConfig', () => {
 		await testServer.start();
 		await webSockets.connect();
 	});
+
 	beforeEach(() => {
 		appContext.clear();
 		authContext.clear();
 	});
+
+	afterEach(() => {
+		mockWebSocket.restoreResponse();
+	});
+
 	after(async() => {
 		logger.log.restore();
 		logger.json.restore();
@@ -50,12 +57,19 @@ describe('setAppConfig', () => {
 	});
 
 	it('should set correct app config', async() => {
+		mockWebSocket.mockResponse({
+			appId: 'appId',
+			versionId: 'versionId',
+		});
+
 		authContext.setContext(sessionConstants.AUTOMATED, 'deviceId');
 		await setAppConfig('configId', {url: 'url'});
 
 		assert.deepEqual(appContext.context, {
 			configId: 'configId',
 			configOverride: {url: 'url'},
+			appId: 'appId',
+			versionId: 'versionId',
 		});
 	});
 });

--- a/test/utils/socketErrorMessages.test.js
+++ b/test/utils/socketErrorMessages.test.js
@@ -391,7 +391,7 @@ describe('Socket error messages', () => {
 			[basePayload('missingCpp'), 'Make sure you have Microsoft Visual C++ Redistributable installed. Please see our docs - https://suite.st/docs/devices/playstation.'],
 			[
 				set(lensPath(['chainData', 'testId']), 'testId', basePayload('testSnippetError')),
-				'Test run by ID "testId" failed.',
+				'Chain description.',
 			],
 			[
 				set(lensPath(['chainData', 'testId']), 'testId', basePayload('invalidReference')),


### PR DESCRIPTION
Fetch test definitions in runTest chain and display output for each snippet line result. 
Requires proper line translations when ready.