### PR TITLE
SUIT-17319 Increased min node version up to 14. Removed deprecated me…

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -22,18 +22,16 @@ const overridableFields = [
 	'includeChangelist',
 ];
 
-const configurableFields = ['logLevel', 'disallowCrashReports', 'defaultTimeout'];
-
-const serverAdress = process.env[envVars.SUITEST_BE_SERVER] || 'the.suite.st';
+const serverAddress = process.env[envVars.SUITEST_BE_SERVER] || 'the.suite.st';
 
 const main = Object.freeze({
-	apiUrl: `https://${serverAdress}/api/public/v4`,
+	apiUrl: `https://${serverAddress}/api/public/v4`,
 	disallowCrashReports: false,
 	logLevel: logLevels.normal,
 	sentryDsn,
 	timestamp: timestamp.default,
 	defaultTimeout: DEFAULT_TIMEOUT,
-	wsUrl: `wss://${serverAdress}/api/public/v4/socket`,
+	wsUrl: `wss://${serverAddress}/api/public/v4/socket`,
 });
 
 const test = Object.freeze({
@@ -72,7 +70,6 @@ const configFactory = () => {
 	return {
 		config,
 		overridableFields,
-		configurableFields,
 		extend,
 		override,
 	};

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,16 +52,10 @@ declare namespace suitest {
 		setAppConfig(configId: string, options?: ConfigOverride): Promise<void|SuitestError>;
 		pairDevice(deviceId: string): Promise<DeviceData|SuitestError>;
 		releaseDevice(): Promise<void|SuitestError>;
-		interactive(options?: ReplOptions): Promise<void>;
+		startREPL(options?: ReplOptions): Promise<void>;
 
 		// config
 		getConfig(): ConfigureOptions;
-
-		// TODO: remove it and update UT
-		/**
-		 * @deprecated use separate methods for changing configuration properties
-		 */
-		configure(config: Partial<ConfigureOptions>): void;
 		setDefaultTimeout(timeout: ConfigureOptions['defaultTimeout']): void;
 		setContinueOnFatalError(continueOnFatalError: ConfigureOptions['continueOnFatalError']): void;
 		setDisallowCrashReports(disallowCrashReports: ConfigureOptions['disallowCrashReports']): void;
@@ -281,10 +275,6 @@ declare namespace suitest {
 		defaultTimeout: number;
 	}
 
-	interface ResponseError {
-		errorType: string;
-	}
-
 	interface Context {
 		context: unknown;
 		setContext(context: unknown): void;
@@ -320,8 +310,6 @@ declare namespace suitest {
 		size?: string,
 		color?: string,
 		index?: number,
-		video?: true,
-		psVideo?: true,
 	}
 
 	type ScreenOrientationValues =

--- a/lib/api/webSockets.js
+++ b/lib/api/webSockets.js
@@ -11,7 +11,7 @@ const fetch = require('node-fetch');
 
 const SuitestError = require('../utils/SuitestError');
 const texts = require('../texts');
-const {handleProgress} = require('../utils/interactiveProgressHandler');
+const {handleProgress} = require('../utils/progressHandler');
 const {getInfoErrorMessage} = require('../utils/socketErrorMessages');
 const {translateNotStartedReason} = require('../utils/translateResults');
 const logLevels = require('../../lib/constants/logLevels');

--- a/lib/chains/elementChain.js
+++ b/lib/chains/elementChain.js
@@ -35,7 +35,6 @@ const {
 } = require('../composers');
 const {
 	invalidInputMessage,
-	warnVideoAsElementDeprecation,
 	assertElementMalformed,
 } = require('../texts');
 const {validate, validators} = require('../validation');
@@ -267,14 +266,8 @@ const elementFactory = (classInstance, video) => {
 		return output;
 	};
 
-	const deprecatedVideo = util.deprecate(video, warnVideoAsElementDeprecation());
-
 	const elementChain = elementSelector => {
 		const selector = typeof elementSelector === 'string' ? {apiId: elementSelector} : elementSelector;
-
-		if (selector && selector.video && Object.keys(selector).length === 1) {
-			return deprecatedVideo();
-		}
 
 		return makeChain(classInstance, getComposers, {
 			type: 'element',

--- a/lib/commands/pairDevice.js
+++ b/lib/commands/pairDevice.js
@@ -29,7 +29,7 @@ async function pairDevice({webSockets, authContext, logger, pairedDeviceContext}
 			SuitestError.INVALID_INPUT,
 		);
 
-	const deviceName = deviceDetails.deviceName;
+	const deviceName = deviceDetails.displayName;
 
 	logger.delayed(connectingToDevice(deviceName, deviceId), 4e3);
 

--- a/lib/commands/startREPL.js
+++ b/lib/commands/startREPL.js
@@ -25,7 +25,7 @@ let replModeWasActivated = false;
  * @returns {*[]}
  */
 function getReplParameters(opts, suitest) {
-	// get dir where .interactive() was called
+	// get dir where .startREPL() was called
 	const callFile = path.normalize(stackTraceParser(new Error())[2].file);
 	const cwd = opts.cwd || path.dirname(callFile);
 	const file = path.basename(callFile);
@@ -45,7 +45,7 @@ function getReplParameters(opts, suitest) {
  * @param {Function=} opts.repeater
  * @returns {Promise} response object
  */
-async function interactive(opts = {}) {
+async function startREPL(opts = {}) {
 	if (!replModeWasActivated) {
 		replModeWasActivated = true;
 		captureMessage('REPL mode activated');
@@ -60,10 +60,10 @@ async function interactive(opts = {}) {
 	if (isReplActive)
 		return Promise.resolve();
 
-	const {replWarnInteractive, replWelcomeMessage, replSessionEnded} = texts;
+	const {replWarn, replWelcomeMessage, replSessionEnded} = texts;
 
 	if (!suitest.config.runsOnSingleDevice) {
-		logger.warn(replWarnInteractive());
+		logger.warn(replWarn());
 
 		return Promise.resolve();
 	}
@@ -90,4 +90,4 @@ async function interactive(opts = {}) {
 	logger.info(replSessionEnded());
 }
 
-module.exports = interactive;
+module.exports = startREPL;

--- a/lib/constants/ipcMessageId.js
+++ b/lib/constants/ipcMessageId.js
@@ -1,7 +1,7 @@
 const messageId = Object.freeze({
 	SETUP_SESSION: 'SETUP_SESSION', // passed from launcher to child on child connect, contains config object
 
-	REPL_START: 'REPL_START', // sent from child to launcher when interactive() is called,
+	REPL_START: 'REPL_START', // sent from child to launcher when startREPL() is called,
 	REPL_INIT: 'REPL_INIT', // launcher does some manipulations and sends REPL_INIT back
 	REPL_STOP: 'REPL_STOP', // send from child to parent when repl is closed
 });

--- a/lib/testLauncher/SuitestLauncher.js
+++ b/lib/testLauncher/SuitestLauncher.js
@@ -13,12 +13,16 @@ const sessionConstants = require('../constants/session');
 const {getDevicesDetails} = require('../utils/getDeviceInfo');
 const {closeSessionUnchained} = require('../commands/closeSession');
 const {captureException} = require('../utils/sentry/Raven');
-const {
-	launcherGreeting,
-} = require('../texts');
+const t = require('../texts');
 const {version} = require('../../package.json');
 const ipcServer = require('./ipc/server');
 const suitest = require('../../index');
+const SuitestError = require('../utils/SuitestError');
+
+function exitProcessWithError(message) {
+	suitest.logger.error(message);
+	process.exit(1);
+}
 
 class SuitestLauncher {
 	constructor(ownArgv = {}, restArgs = []) {
@@ -31,14 +35,13 @@ class SuitestLauncher {
 	}
 
 	async runTokenSession() {
-		suitest.logger.intro(launcherGreeting, version, TOKEN);
+		suitest.logger.intro(t.launcherGreeting, version);
 		validateInput(TOKEN.toUpperCase(), this.ownArgv);
 		const appConfigIdAndDeviceIdPresented = this.ownArgv.appConfigId && this.ownArgv.deviceId;
 		const presetArrayDefined = this.ownArgv.preset && this.ownArgv.preset.length > 0;
 
 		if (!appConfigIdAndDeviceIdPresented && !presetArrayDefined) {
-			suitest.logger.error('Please specify Configuration id and device id, or presets');
-			process.exit(1);
+			exitProcessWithError(t['errorType.specifyRunningDevices']());
 		}
 
 		// check that presets are exists only if appConfigId and deviceId not specified via cli
@@ -47,13 +50,11 @@ class SuitestLauncher {
 			const notFoundPresets = this.ownArgv.preset.filter(p => !definedPresets.includes(p));
 
 			if (notFoundPresets.length > 0) {
-				suitest.logger.error(`Presets ${notFoundPresets.join(', ')} were not found in your configuration`);
-				process.exit(1);
+				exitProcessWithError(t['errorType.notFoundPresets'](notFoundPresets));
 			}
 		}
 
 		try {
-			// TODO: add validation for availability "presets" or ("deviceId" and "appConfigId") here or in jsonSchemas
 			const devices = appConfigIdAndDeviceIdPresented
 				? [{
 					device: this.ownArgv.deviceId,
@@ -78,6 +79,10 @@ class SuitestLauncher {
 			const devicesWithDetails = await getDevicesDetails(suitest, devices);
 			const runsOnSingleDevice = devicesWithDetails.length === 1;
 
+			if (devicesWithDetails.length === 0) {
+				throw new SuitestError(t['errorType.noDevices']());
+			}
+
 			// should be allowed for single device only
 			if (isDebugMode(this.ownArgv) && !runsOnSingleDevice) {
 				throwDebugForManyDevicesError();
@@ -87,9 +92,6 @@ class SuitestLauncher {
 				const ipcPort = await ipcServer.start({
 					...this.ownArgv,
 					launcherVersion: version,
-					sessionToken: Buffer
-						.from(`${this.ownArgv.tokenId}:${this.ownArgv.tokenPassword}`)
-						.toString('base64'),
 					isDebugMode: isDebugMode(this.ownArgv),
 					runsOnSingleDevice,
 					sessionType: TOKEN,

--- a/lib/testLauncher/commands/run.js
+++ b/lib/testLauncher/commands/run.js
@@ -31,7 +31,7 @@ const builder = yargs => {
 			global: false,
 		})
 		.option('preset', {
-			describe: 'Present for configuration and device.',
+			describe: 'Preset for configuration and device.',
 			array: true,
 			global: false,
 		})

--- a/lib/testLauncher/repl.js
+++ b/lib/testLauncher/repl.js
@@ -59,7 +59,7 @@ function setupRepl(opts, isTTY) {
 
 	const watcher = chokidar.watch(watch, {ignored, cwd}).on(
 		'change',
-		file => setTimeout(() => onFileChange(file, cwd, callFile, repeater), 50)
+		file => setTimeout(() => onFileChange(file, cwd, callFile, repeater), 50),
 	);
 
 	const prompt = 'Suitest $ ';
@@ -89,7 +89,7 @@ function setupRepl(opts, isTTY) {
  * Module resolution is relative to cwd.
  * @param {String} repeater - string representation of repeater
  * @param {String} cwd - current working directory
- * @param {string} callFilename - name of the file where "interactive" was called.
+ * @param {string} callFilename - name of the file where "startREPL" was called.
  * @returns {*}
  */
 function repeaterFromString(repeater, cwd, callFilename) {
@@ -137,7 +137,7 @@ async function onFileChange(file, cwd, callFile, repeater) {
 	const funcBody = colors.white(getShortFunctionBody(func));
 
 	console.log(colors.magenta(
-		replFilesChanged(funcBody)
+		replFilesChanged(funcBody),
 	));
 
 	// Run the repeater without allowing the process to exit with an error

--- a/lib/texts.js
+++ b/lib/texts.js
@@ -80,13 +80,12 @@ Put an "await" in front of those chains or call .abandon() to suppress these war
 ${leaves}`,
 
 	// test launcher
-	// TODO fix using runMode
-	launcherGreeting: (version, runMode) => {
+	launcherGreeting: (version) => {
 		const offsetInHours = (new Date()).getTimezoneOffset() / 60;
 
 		return '' +
 		`Hi there! This is Suitest test launcher v${version}.\n` +
-		`Preparing to start execution in ${runMode.toLowerCase()} mode ...\n` +
+		'Preparing to start execution ...\n' +
 		`← Time logs are provided in local time zone (UTC${offsetInHours > 0 ? '-' : '+'}${Math.abs(offsetInHours)})\n\n`;
 	},
 
@@ -141,6 +140,9 @@ ${leaves}`,
 	'errorType.suitestCommand': template`provided for 'suitest ${0}' command. It`,
 	'errorType.suitestTestCommand': `Seems you forgot to provide a test command${EOL}check https://suite.st/docs/suitest-api/test-launcher/#usage for more info`,
 	'errorType.testCannotBeFetched': (testId, mainTest) => `Test cannot be fetched test id: ${mainTest ? mainTest + ' > ... > ' + testId : testId}`,
+	'errorType.noDevices': () => 'There no devices associated with current configuration',
+	'errorType.specifyRunningDevices': () => 'Please specify Configuration id and device id, or presets',
+	'errorType.notFoundPresets': (notFoundPresets) => `Presets ${notFoundPresets.join(', ')} were not found in your configuration`,
 
 	executorStopped: () => 'Test execution was stopped. See our documentation for possible reasons: https://suite.st/docs/error-messages/results-errors/#test-execution-was-stopped',
 
@@ -168,11 +170,7 @@ ${leaves}`,
 	disconnectedFromDevice: () => 'Disconnected from device',
 	disconnectingFromDevice: () => 'Disconnecting from device',
 
-	// Warnings
-	warnConfigureDeprecation: () => '.configure() command is deprecated and will be removed soon. Use separete commands for each field or .suitestrc file or cli args for configuration.',
-	warnVideoAsElementDeprecation: () => '.element({video: true}) is deprecated and will be removed soon, use .video() instead.',
-
-	replWarnInteractive: () => 'Ignored the "interactive" command. This command works only for single device.',
+	replWarn: () => 'Ignored the "startREPL" command. This command works only for single device.',
 	replWelcomeMessage: (vars, cwd, watch, repeater, varColor) => {
 		return '' +
 		'Test execution has been paused for the interactive session\n' +
@@ -195,11 +193,11 @@ ${leaves}`,
 	replFailedToRequire: template`Failed to require file ${0}. (You may need to update your "watch" parameter)`,
 	replIpcErrorInChildProcess: template`IPC error in child process `,
 	replIpcNotImplemented: template`IPC protocol not implemented for message: ${0}`,
-	replIpcNotAvailable: template`suitest.interactive() command only works when used together with Suitest launcher.`,
+	replIpcNotAvailable: template`suitest.startREPL() command only works when used together with Suitest launcher.`,
 	replFailedToFindRepeater: template`Error: Failed to find the repeater "${0}".`,
 	replRepeaterNotAFunc: template`Error: Repeater "${0}" is not a function. Value: ${1}`,
-	replNotATty: template`You seem to be using suitest from a CLI that is not a TTY. Some features of suitest.interactive command may not work as expected. In case of problems try switching to the default system's CLI program, like bash on Linux or cmd on Windows. Sometimes replacing "suitest" command with "node node_modules/suitest-js-api/lib/testLauncher/" could help as well`,
-	replWrongNodeVersion: template`Error: To use "suitest.interactive" you need NodeJS version v9.4 or newer. You are using ${0}. Please update.`,
+	replNotATty: template`You seem to be using suitest from a CLI that is not a TTY. Some features of suitest.startREPL command may not work as expected. In case of problems try switching to the default system's CLI program, like bash on Linux or cmd on Windows. Sometimes replacing "suitest" command with "node node_modules/suitest-js-api/lib/testLauncher/" could help as well`,
+	replWrongNodeVersion: template`Error: To use "suitest.startREPL" you need NodeJS version v9.4 or newer. You are using ${0}. Please update.`,
 
 	// Cli args
 	cliLogLevel: () => `Logger verbosity level [default: "${logLevels.normal}"]`,

--- a/lib/utils/AuthContext.js
+++ b/lib/utils/AuthContext.js
@@ -85,7 +85,6 @@ class AuthContext extends Context {
 		super();
 
 		this.headers = {};
-		// TODO: make it private in case of incsreasing minimum nodejs version
 		this.tokenId = '';
 		this.tokenPassword = '';
 		super.setContext(sessionConstants.GUEST);

--- a/lib/utils/SuitestError.js
+++ b/lib/utils/SuitestError.js
@@ -51,7 +51,6 @@ SuitestError.type = suitestErrorType;
 
 // Assign error codes as static values
 // Make it a static assignment to allow for better IDE support
-// TODO: check that all code are uses
 SuitestError.AUTH_NOT_ALLOWED = Symbol('authNotAllowed');
 SuitestError.AUTH_FAILED = Symbol('authFailed');
 SuitestError.INVALID_INPUT = Symbol('invalidInput');

--- a/lib/utils/progressHandler.js
+++ b/lib/utils/progressHandler.js
@@ -1,5 +1,5 @@
 /**
- * During an interactive test execution there are often periods of time
+ * During a test execution there are often periods of time
  * where longer waits occur and it is not immediately obvious why it is so.
  * In this case server sends WS events with content type 'progress'.
  * Description is printed to stdout.

--- a/lib/utils/sessionStarter.js
+++ b/lib/utils/sessionStarter.js
@@ -5,7 +5,7 @@ const {captureException} = require('./sentry/Raven');
 const envVars = require('../constants/enviroment');
 const messageId = require('../constants/ipcMessageId');
 const ipcClient = require('../testLauncher/ipc/client');
-const {replWarnInteractive} = require('../texts');
+const {replWarn} = require('../texts');
 const wsContentTypes = require('../api/wsContentTypes');
 
 // Unchained commands
@@ -62,11 +62,11 @@ const bootstrapSession = async(suitest, {deviceId, configId, presetName}) => {
 				await suitest.webSockets.send({type: wsContentTypes.enableDebugMode});
 			}
 
-			// add interactive command only to child process instance and if running single device
-			suitest.interactive = suitest.config.runsOnSingleDevice
-				? require('../../lib/commands/interactive')
+			// add startREPL command only to child process instance and if running single device
+			suitest.startREPL = suitest.config.runsOnSingleDevice
+				? require('../../lib/commands/startREPL')
 				: () => {
-					suitest.logger.warn(replWarnInteractive());
+					suitest.logger.warn(replWarn());
 
 					return Promise.resolve();
 				};

--- a/lib/utils/testHelpers/mockHelpers.js
+++ b/lib/utils/testHelpers/mockHelpers.js
@@ -3,7 +3,6 @@
 const mock = require('mock-require');
 const testLauncherHelper = require('../testLauncherHelper');
 
-// TODO: remove (investigate)?
 mock('../testLauncherHelper', {
 	...testLauncherHelper,
 });

--- a/lib/utils/testHelpers/mockWebSocket.js
+++ b/lib/utils/testHelpers/mockWebSocket.js
@@ -7,7 +7,7 @@ const {v1: uuid} = require('uuid');
 const {config} = require('../../../index');
 const SuitestError = require('../SuitestError');
 const texts = require('../../texts');
-const {handleProgress} = require('../interactiveProgressHandler');
+const {handleProgress} = require('../progressHandler');
 const mock = require('mock-require');
 
 let ws = null,

--- a/lib/validation/jsonSchemas.js
+++ b/lib/validation/jsonSchemas.js
@@ -290,14 +290,45 @@ schemas[validationKeys.RESPONSE_MATCHES] = {
 	},
 };
 
-// TODO: set correct type for presets
 schemas[validationKeys.TEST_LAUNCHER_TOKEN] = {
 	'type': 'object',
 	'required': ['tokenId', 'tokenPassword'],
 	'properties': {
 		'tokenId': {'type': 'string'},
 		'tokenPassword': {'type': 'string'},
-		'presets': {'type': 'object'},
+		'presets': {
+			'type': 'object',
+			'additionalProperties': {
+				'type': 'object',
+				'properties': {
+					'device': {
+						'oneOf': [
+							{'type': 'string'},
+							{
+								'type': 'object',
+								'properties': {
+									'deviceId': {'type': 'string'},
+								},
+								'additionalProperties': false,
+							},
+						],
+					},
+					'config': {
+						'oneOf': [
+							{'type': 'string'},
+							{
+								'type': 'object',
+								'properties': {
+									'configId': {'type': 'string'},
+								},
+								'additionalProperties': false,
+							},
+						],
+					},
+				},
+			},
+
+		},
 		'appConfigId': {'type': 'string'},
 		'deviceId': {'type': 'string'},
 	},

--- a/lib/validation/validators.js
+++ b/lib/validation/validators.js
@@ -101,6 +101,9 @@ function prettifyJsonSchemaErrors(validate) {
 			if (err.keyword === 'enum') {
 				return `${err.message}: "${err.params.allowedValues.join('", "')}"`; // -> ...of the allowed values: "all", "currentUrl"
 			}
+			if (err.dataPath) {
+				return err.dataPath + ' ' + err.message;
+			}
 
 			return err.message;
 		});

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://suite.st/",
   "license": "MIT",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=14.0.0"
   },
   "bin": {
     "suitest": "bin/suitest"

--- a/suitest.js
+++ b/suitest.js
@@ -1,6 +1,5 @@
 require('./lib/utils/sentry/Raven');
-const util = require('util');
-const texts = require('./lib/texts');
+const {clone} = require('ramda');
 
 // Commands
 const {openSession} = require('./lib/commands/openSession');
@@ -83,11 +82,10 @@ class SUITEST_API extends EventEmitter {
 		this.getPairedDevice = () => this.pairedDeviceContext.context;
 		this.configuration = configFactory();
 		this.config = this.configuration.config;
-		// TODO: remove and update UT.
-		this.configure = util.deprecate(this.configuration.override, texts.warnConfigureDeprecation());
-		this.configuration.configurableFields.map(fieldName => {
-			this[`set${fieldName[0].toUpperCase()}${fieldName.slice(1)}`] = (val) => this.configuration.override({[fieldName]: val});
-		});
+		this.setDefaultTimeout = (defaultTimeout) => this.configuration.override({defaultTimeout});
+		this.setContinueOnFatalError = (continueOnFatalError) => this.configuration.override({continueOnFatalError});
+		this.setDisallowCrashReports = (disallowCrashReports) => this.configuration.override({disallowCrashReports});
+		this.setLogLevel = (logLevel) => this.configuration.override({logLevel});
 
 		// creating methods based on instance dependencies
 		this.logger = createLogger(this.configuration.config, this.pairedDeviceContext);
@@ -117,7 +115,7 @@ class SUITEST_API extends EventEmitter {
 		const {jsExpression, jsExpressionAssert} = jsExpressionFactory(this);
 		const {networkRequest, networkRequestAssert} = networkRequestFactory(this);
 		const {video, videoAssert} = videoFactory(this);
-		const {element, elementAssert} = elementFactory(this, video);
+		const {element, elementAssert} = elementFactory(this);
 		const {playstationVideo, playstationVideoAssert} = playstationVideoFactory(this);
 		const {pollUrl, pollUrlAssert} = pollUrlFactory(this);
 		const {runTestAssert} = runTestFactory(this);
@@ -250,7 +248,7 @@ class SUITEST_API extends EventEmitter {
 	}
 
 	getConfig() {
-		return {...this.configuration.config};
+		return clone(this.configuration.config);
 	}
 }
 

--- a/test/testLauncher/index.test.js
+++ b/test/testLauncher/index.test.js
@@ -26,7 +26,7 @@ describe('suitest test launcher', function() {
 			processExecPath(process.execPath),
 			[
 				testLauncherTest, 'run', '--token-id', 'id', '--token-password', 'password',
-				'--device-id', 'deviceid', '--app-config-id', 'configid', 'npm', 'version',
+				'--device-id', 'deviceId', '--app-config-id', 'configid', 'npm', 'version',
 			],
 			{shell: true},
 		).once('exit', (exitCode) => {

--- a/test/testLauncher/run.test.js
+++ b/test/testLauncher/run.test.js
@@ -4,7 +4,7 @@ const SuitestLauncher = require('../../lib/testLauncher/SuitestLauncher');
 const {handler} = require('../../lib/testLauncher/commands/run');
 const logger = require('../../index').logger;
 
-describe('test launcher interactive command', function() {
+describe('test launcher run command', function() {
 	before(async() => {
 		sinon.stub(logger, 'log');
 	});
@@ -13,7 +13,7 @@ describe('test launcher interactive command', function() {
 		logger.log.restore();
 	});
 
-	it('"run" command should and start interactive process', async() => {
+	it('"run" command should start', async() => {
 		const interactiveStub = sinon.stub(SuitestLauncher.prototype, 'runTokenSession');
 
 		try {

--- a/test/utils/interactiveProgressHandler.test.js
+++ b/test/utils/interactiveProgressHandler.test.js
@@ -1,10 +1,10 @@
 const Raven = require('raven');
 const assert = require('assert');
-const {handleProgress} = require('../../lib/utils/interactiveProgressHandler');
+const {handleProgress} = require('../../lib/utils/progressHandler');
 const translate = require('../../lib/utils/translateResults');
 const sinon = require('sinon');
 
-describe('interactiveProgressHandler', () => {
+describe('progressHandler', () => {
 	let translateProgress = () => null;
 
 	beforeEach(() => {

--- a/test/validation/validators.test.js
+++ b/test/validation/validators.test.js
@@ -50,7 +50,71 @@ describe('validators', () => {
 				name: 'string',
 			}],
 		}], {
-			message: 'Invalid input should have required property \'key\'',
+			message: 'Invalid input .configVariables[0] should have required property \'key\'',
 		}, 'invalid configOverride object');
+	});
+
+	it('should validate configuration presets', () => {
+		const baseArg = {
+			tokenId: '1',
+			tokenPassword: '1',
+			preset: ['preset1'],
+		};
+
+		assert.throws(
+			() => validate(
+				validators.TEST_LAUNCHER_TOKEN,
+				{
+					...baseArg,
+					presets: {
+						preset1: {config: false, device: null},
+					},
+				},
+			),
+			/^SuitestError: Invalid input/,
+			'Should validate preset config and device',
+		);
+		assert.throws(
+			() => validate(
+				validators.TEST_LAUNCHER_TOKEN,
+				{
+					...baseArg,
+					presets: {
+						preset1: {
+							config: {
+								configId: false,
+							},
+							device: {
+								deviceId: 123,
+							},
+						},
+					},
+				},
+			),
+			/^SuitestError: Invalid input/,
+			'Should validate preset config.configId and device.deviceId',
+		);
+		assert.throws(
+			() => validate(
+				validators.TEST_LAUNCHER_TOKEN,
+				{
+					...baseArg,
+					presets: {
+						preset1: {
+							config: {
+								configId: 'config-id1',
+								notAllowedProp: 'some val',
+							},
+							device: {
+								deviceId: 'device-id1',
+								anotherNotAllowedProp: 'some val',
+							},
+						},
+					},
+				},
+			),
+			/^SuitestError: Invalid input/,
+			'Should not additional fields to preset config and device if they are objects',
+		);
 	});
 });


### PR DESCRIPTION
…thods suitest.element({ video: true }), suitest.configure({ }). Renamed suitest.interactive() -> suitest.startREPL(). Improved validation for TEST_LAUNCHER_TOKEN schema. Fixed typo in "preset" cli option description. Exit with error if any devices info were not found. UT updates