### PR TITLE
SUIT-19461

### DIFF
--- a/lib/testLauncher/commands/run.js
+++ b/lib/testLauncher/commands/run.js
@@ -43,10 +43,21 @@ const builder = yargs => {
 			describe: 'Will launch user command with --inspect-brk execArgv, used for debugging',
 			global: false,
 		})
+		.option('override-config-file', {
+			describe: 'Specifies an additional config file which properties have precedence over properties in a standard configuration file.',
+			global: false,
+			type: 'string',
+		})
+		.option('base-config-file', {
+			describe: 'Path to a config file to override standard configuration files. Standard configuration files are ignored.',
+			global: false,
+			type: 'string',
+		})
 		.option('config-file', {
 			describe: texts.cliConfig(),
 			global: false,
 			type: 'string',
+			deprecate: 'Can have unexpected behaviour. Use --base-config-file or --override-config-file.',
 		})
 		.option('default-timeout', {
 			describe: texts.defaultTimeout(),

--- a/lib/testLauncher/composeConfig.js
+++ b/lib/testLauncher/composeConfig.js
@@ -212,14 +212,14 @@ function readRcConfig(pathToConfig) {
 }
 
 /**
- * Read json config file provided by user.
+ * Read config file provided by user.
  * @param {string} path - path to config file
  * @throws {SuitestError}
- * @returns {Object} - parsed json
+ * @returns {Object} - parsed config file
  */
 function readUserConfig(path) {
 	try {
-		return JSON.parse(fs.readFileSync(path));
+		return readConfigFile(path);
 	} catch (error) {
 		throw new SuitestError(invalidUserConfig(path, error.message), error.code);
 	}

--- a/lib/testLauncher/composeConfig.js
+++ b/lib/testLauncher/composeConfig.js
@@ -70,6 +70,8 @@ function readConfigFile(filePath) {
 			return ini.parse(fileContent);
 		case '.js':
 			return require(filePath);
+		case '.json':
+			return JSON.parse(fileContent);
 		default:
 			try {
 				return JSON.parse(fileContent);

--- a/lib/testLauncher/composeConfig.js
+++ b/lib/testLauncher/composeConfig.js
@@ -58,9 +58,17 @@ const DEFAULT_PATHS = [
  * @param {String} filePath path to file
  */
 function readConfigFile(filePath) {
+	const extension = path.extname(filePath);
+	if (extension === '.js') {
+		if (!path.isAbsolute(filePath)) {
+			// ensure correct handling of relative paths, we want to prevent searching in __dirname
+			filePath = path.join(process.cwd(), filePath);
+		}
+		return require(filePath);
+	}
 	const fileContent = fs.readFileSync(filePath, 'utf8');
 
-	switch (path.extname(filePath)) {
+	switch (extension) {
 		case '.yaml':
 		case '.yml':
 			return yaml.load(fileContent);
@@ -68,8 +76,6 @@ function readConfigFile(filePath) {
 			return JSON5.parse(fileContent);
 		case '.ini':
 			return ini.parse(fileContent);
-		case '.js':
-			return require(filePath);
 		case '.json':
 			return JSON.parse(fileContent);
 		default:

--- a/lib/testLauncher/composeConfig.js
+++ b/lib/testLauncher/composeConfig.js
@@ -172,9 +172,6 @@ function readRcConfig(pathToConfig) {
 			.filter(defaultConfig => IS_WINDOWS ? defaultConfig.isGeneral : true);
 
 		for (const defaultConfig of defaultConfigurations) {
-			if (mainConfigFilePath) {
-				break;
-			}
 			if (
 				fs.existsSync(defaultConfig.path) &&
 				fs.lstatSync(defaultConfig.path).isDirectory()
@@ -183,6 +180,9 @@ function readRcConfig(pathToConfig) {
 					defaultConfig.deepSearch ?
 						findConfigUpToRoot :
 						findConfig)(defaultConfig.path, defaultConfig.filename);
+				if (mainConfigFilePath) {
+					break;
+				}
 			}
 		}
 	}

--- a/lib/testLauncher/composeConfig.js
+++ b/lib/testLauncher/composeConfig.js
@@ -160,6 +160,7 @@ function findConfigUpToRoot(pathToSearch, filename) {
  * Searches for 'extends' property for other config file and if presents merge them.
  * cli arguments are not parsed.
  * If file found, but json invalid, throw error.
+ * @param {string} [pathToConfig] expicit path to configuration file
  * @returns {Object}
  */
 function readRcConfig(pathToConfig) {
@@ -231,8 +232,20 @@ function readUserConfig(path) {
  * @returns {{ownArgs: Object, userCommandArgs: string[]}}
  */
 const composeConfig = (argv) => {
-	const rcConfig = readRcConfig(argv.configFile);
-	const configFilePath = argv.configFile || rcConfig.configFile;
+	if (argv.configFile) {
+		console.warn('Warning: You are using deprecated argument --config-file. Please use --override-config-file or --base-config-file instead.');
+		if (argv.baseConfigFile || argv.overrideConfigFile) {
+			throw new SuitestError('Combination of deprecated --config-file with either --base-config-file or --override-config-file is not allowed');
+		}
+	}
+	const rcConfig = readRcConfig(argv.baseConfigFile || argv.configFile);
+	if (rcConfig.configFile) {
+		console.warn('Warning: You are using deprecated option configFile. Please use overrideConfigFile instead.');
+	}
+	if ((argv.configFile || rcConfig.configFile) && (argv.baseConfigFile || argv.overrideConfigFile || rcConfig.overrideConfigFile)) {
+		throw new SuitestError('Combination of deprecated configFile with --base-config-file or --override-config-file or overrideConfigFile is not allowed');
+	}
+	const configFilePath = argv.overrideConfigFile || rcConfig.overrideConfigFile || argv.configFile || rcConfig.configFile;
 	const userConfig = configFilePath ? readUserConfig(configFilePath) : {};
 
 	const ownArgs = {

--- a/lib/texts.js
+++ b/lib/texts.js
@@ -41,7 +41,7 @@ module.exports = {
 	invalidInputMessage: (methodName, field) =>
 		`provided for .${methodName} function.` + (field ? ` ${field}` : ''),
 	invalidConfigObj: () => 'provided for configuration object.',
-	invalidUserConfig: template`Failed to process config file '${0}'.\n\t${1}.\n\tMake sure path is correct and file is in valid json format.`,
+	invalidUserConfig: template`Failed to process config file '${0}'.\n\t${1}.\n\tMake sure path is correct and file is in valid format.`,
 	circularDependencyError: (path) => `Circular dependency found on ${path} path.`,
 
 	// WebSockets errors

--- a/lib/validation/jsonSchemas.js
+++ b/lib/validation/jsonSchemas.js
@@ -362,6 +362,7 @@ schemas[validationKeys.CONFIGURE] = {
 	'properties': {
 		'appConfigId': {'type': 'string'},
 		'concurrency': {'type': 'number'},
+		'overrideConfigFile': {'type': 'string'},
 		'configFile': {'type': 'string'},
 		'deviceId': {'type': 'string'},
 		'disallowCrashReports': {'type': 'boolean'},

--- a/test/testLauncher/composeConfig.test.js
+++ b/test/testLauncher/composeConfig.test.js
@@ -29,20 +29,32 @@ describe('testLauncher readUserConfig', () => {
 		}
 	});
 
+	it('readUserConfig method should support other types of config files', () => {
+		// for test simplicity, only single format is used
+		sinon.stub(fs, 'readFileSync').returns('test: true');
+		const expected = {test: true};
+
+		try {
+			assert.deepStrictEqual(readUserConfig('.file.yml'), expected, 'parsed successfully');
+		} finally {
+			fs.readFileSync.restore();
+		}
+	});
+
 	it('readUserConfig method should throw correct errors', () => {
 		assert.throws(
 			() => readUserConfig(path.join('.', '__non-such-dir__', '__non-such-file__.json')),
 			err => err.type === SuitestError.type,
-			'falied to read file',
+			'failed to read file',
 		);
 
 		sinon.stub(fs, 'readFileSync').returns('invalid json');
 
 		try {
 			assert.throws(
-				() => readUserConfig(''),
+				() => readUserConfig('file.json'),
 				err => err.type === SuitestError.type,
-				'falied to parse json',
+				'failed to parse json',
 			);
 		} finally {
 			fs.readFileSync.restore();


### PR DESCRIPTION
Because of `--config-file` argument produces different results than `configFile` settings, this PR deprecates both config file settings and introduces two new options:
- `--nase-config-file`
- `--override-config-file`/`overrideConfigFile`

with the clearly defined behaviour.

This PR also fixes #449.