### PR TITLE
SUIT-21085 fix failing IPC on systems where localhost is resolved to IPv6 address

### DIFF
--- a/lib/testLauncher/ipc/client.js
+++ b/lib/testLauncher/ipc/client.js
@@ -26,7 +26,7 @@ const disconnect = () => {
  */
 /* istanbul ignore next */
 const connect = (port) => {
-	state.socket = net.connect(port, 'localhost');
+	state.socket = net.connect(port, '127.0.0.1');
 	state.socket.on('error', err => console.debug('IPC client socket error', err.errno, err));
 	state.socket.on('close', disconnect);
 	state.socket.on('data', handleMessageFromServer);

--- a/lib/testLauncher/ipc/server.js
+++ b/lib/testLauncher/ipc/server.js
@@ -53,7 +53,7 @@ const start = config => {
 	server.unref();
 
 	return new Promise((resolve, reject) => {
-		server.listen(0, 'localhost', err => {
+		server.listen(0, '127.0.0.1', err => {
 			err ? reject(err) : resolve(server.address().port);
 		});
 	});


### PR DESCRIPTION
It fixes `IPC client socket error -111 Error: connect ECONNREFUSED`