### PR TITLE
Fix return type in startRecording to include string

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -66,7 +66,7 @@ declare namespace suitest {
 		releaseDevice(): Promise<void|SuitestError>;
 		startREPL(options?: ReplOptions): Promise<void>;
 		getAppConfig(): Promise<AppConfiguration|SuitestError>;
-		startRecording({webhookUrl}?: {webhookUrl: string}): Promise<void|SuitestError>;
+		startRecording({webhookUrl}?: {webhookUrl: string}): Promise<string|void|SuitestError>;
 		stopRecording({discard}?: {discard: boolean}): Promise<void|SuitestError>;
 
 		// config

--- a/lib/commands/startRecording.js
+++ b/lib/commands/startRecording.js
@@ -9,7 +9,7 @@ const {startRecordingMessage} = require('../texts');
 /**
  * Start recording
  * @param {SUITEST_API} instance of main class
- * @returns {ChainablePromise.<void>}
+ * @returns {ChainablePromise.<string | undefined>}
  */
 async function startRecording({webSockets, authContext, logger}, recordingSettings) {
 	const webhookUrl = recordingSettings ? recordingSettings.webhookUrl : undefined;


### PR DESCRIPTION
Since https://github.com/SuitestAutomation/suitest-js-api/commit/08e1d84b64199e46c0aaf221854e4a521116fd08, the `startRecording()` API has been updated to return a promise that resolves to the recording URL (which is a string).

This PR updates the return type annotation in `index.d.ts` to accurately reflect the API’s expected behavior, enhancing type safety and ensuring consistency between the implementation and its type definition.