### PR TITLE
 Review getPairedDevice return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -171,13 +171,29 @@ declare namespace suitest {
 			model: string,
 			owner: string,
 			firmware: string,
+			osVersion?: string,
 			modelId: string,
 			platforms: string[],
-			customName?: string,
+			customName: string,
+			ipAddress: string,
+			controlUnitIds: string[],
 			inactivityTimeout?: number,
 			status: string,
 			displayName?: string,
 			shortDisplayName?: string,
+			customUserInfo?: {
+				location?: string,
+				team?: string,
+				responsibleUser?: string,
+				osInfo?: string,
+				otherInfo?: string,
+			},
+			inUseBy?: {
+				description?: string,
+				email?: string,
+				orgName?: string,
+				tokenName?: string,
+			},
 		}
 
 		// constants


### PR DESCRIPTION
When registering a device it is possible to fill `Other info`, when calling `suitest.getPairedDevice` that information is supplied but it does not appear in the type.

<img width="526" height="469" alt="Screenshot 2025-09-29 at 17 13 47" src="https://github.com/user-attachments/assets/ca9e158e-ec74-49ac-a375-17df62e2487d" />

This patch reviews `getPairedDevice` return type by comparing the `/device/{deviceid}` endpoint documented in the [suitest api reference](https://suite.st/docs/suitest-network-api/api-reference) and filling the missing entities in the returned type.

