### PR TITLE
remove uuid package from production dependencies

### DIFF
--- a/lib/api/webSockets.js
+++ b/lib/api/webSockets.js
@@ -4,7 +4,7 @@
  * WebSockets client module.
  */
 const WS = require('ws');
-const {v1: uuid} = require('uuid');
+const uuid = require('../utils/uuid');
 const {path} = require('ramda');
 const {captureException} = require('../utils/sentry/Sentry');
 const {fetch, setUserAgent} = require('../utils/fetch');

--- a/lib/utils/testHelpers/mockWebSocket.js
+++ b/lib/utils/testHelpers/mockWebSocket.js
@@ -3,7 +3,7 @@
  * Mocked WebSockets client module.
  */
 const MockWebSocket = require('mock-socket').WebSocket;
-const {v1: uuid} = require('uuid');
+const uuid = require('../uuid');
 const {config} = require('../../../index');
 const SuitestError = require('../SuitestError');
 const texts = require('../../texts');

--- a/lib/utils/uuid.js
+++ b/lib/utils/uuid.js
@@ -1,0 +1,7 @@
+const crypto = require("crypto");
+
+function uuid() {
+	return crypto.randomUUID();
+}
+
+module.exports = uuid;

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "ramda": "^0.27.0",
         "semver": "^7.3.2",
         "stack-trace": "^0.0.10",
-        "uuid": "8.1.0",
         "ws": "^7.5.10",
         "yargs": "^15.3.1",
         "yargs-parser": "^18.1.3"
@@ -52,7 +51,7 @@
         "typescript": "5.8.3"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=14.17.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4583,14 +4582,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
-      "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
@@ -8251,11 +8242,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "uuid": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
-      "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg=="
     },
     "v8-compile-cache": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=14.17.0"
   },
   "bin": {
     "suitest": "bin/suitest"
@@ -119,7 +119,6 @@
     "ramda": "^0.27.0",
     "semver": "^7.3.2",
     "stack-trace": "^0.0.10",
-    "uuid": "8.1.0",
     "ws": "^7.5.10",
     "yargs": "^15.3.1",
     "yargs-parser": "^18.1.3"

--- a/test/commands/pairDevice.test.js
+++ b/test/commands/pairDevice.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const {v1: uuid} = require('uuid');
+const uuid = require('../../lib/utils/uuid');
 const nock = require('nock');
 
 const testServer = require('../../lib/utils/testServer');

--- a/test/utils/sessionStarter.test.js
+++ b/test/utils/sessionStarter.test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const sinon = require('sinon');
-const {v1: uuid} = require('uuid');
+const uuid = require('../../lib/utils/uuid');
 const nock = require('nock');
 const testServer = require('../../lib/utils/testServer');
 const webSockets = require('../../lib/api/webSockets');


### PR DESCRIPTION
audit reports problem with uuid, issue could not happen with our usecase but still remove it just to resolve one false positive item.

Minimum supported node version was increased to match introduction of randomUUID function.